### PR TITLE
FM-3763 Use YUM to install Katello CA certificate

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,7 +86,7 @@ class satellite_pe_tools(
   if ($manage_default_ca_cert) and ($::osfamily == 'RedHat') {
     exec {'download_install_katello_cert_rpm':
       path    => '/usr/bin',
-      command => "curl -k ${satellite_url}/pub/katello-ca-consumer-latest.noarch.rpm > /tmp/katello-ca-consumer-latest.noarch.rpm ; rpm -i /tmp/katello-ca-consumer-latest.noarch.rpm",
+      command => "curl -k ${satellite_url}/pub/katello-ca-consumer-latest.noarch.rpm > /tmp/katello-ca-consumer-latest.noarch.rpm ; yum install /tmp/katello-ca-consumer-latest.noarch.rpm",
       creates => '/etc/rhsm/ca/katello-server-ca.pem'
     }
 


### PR DESCRIPTION
Previous to this commit, the satellite_pe_tools class used the rpm
command to install the katello-ca-consumer-latest.noarch.rpm. This would
fail on systems that don't already have the subscription-manager package
installed since the rpm command doesn't perform dependency resolution.

This commit uses the yum command to install the RPM which installs all
the dependencies required for the package.
