### PR TITLE
Manage file ownership and restart Puppet Server

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,6 +71,7 @@ class satellite_pe_tools(
     setting              => 'reports',
     subsetting           => 'satellite',
     subsetting_separator => ',',
+    notify               => Service['pe-puppetserver'],
     before               => File['satellite_config_yaml'],
   }
 
@@ -81,6 +82,7 @@ class satellite_pe_tools(
     owner   => pe-puppet,
     group   => pe-puppet,
     mode    => '0644',
+    notify  => Service['pe-puppetserver'],
   }
 
   if ($manage_default_ca_cert) and ($::osfamily == 'RedHat') {
@@ -95,6 +97,24 @@ class satellite_pe_tools(
       target  => '/etc/rhsm/ca/katello-server-ca.pem',
       require => Exec['download_install_katello_cert_rpm'],
       before  => File['satellite_config_yaml'],
+    }
+  }
+
+  if $ssl_cert {
+    file { $ssl_cert:
+      ensure => file,
+      owner  => 'pe-puppet',
+      group  => 'pe-puppet',
+      mode   => 0640,
+    }
+  }
+
+  if $ssl_key {
+    file { $ssl_key:
+      ensure => file,
+      owner  => 'pe-puppet',
+      group  => 'pe-puppet',
+      mode   => 0640,
     }
   }
 }


### PR DESCRIPTION
Previous to this commit, if the satellite tools configuration file
experience change, the pe-puppetserver service would not be restarted,
requiring the user to do it for the change to take effect. This is not
always clear to the user.

Further, when users add the SSL key and certificate for the master to
communicate with the Satellite server, if they forget to change the
permissions of the files to pe-puppet, it will be unclear why the
communication is failing.

This commit notifies the pe-puppetserver to restart if the satellite
tools config file experiences change.  Also, if the user specifies a
path for the key and certificate, we will ensure the files have the
correct ownership and mode.
