### PR TITLE
Restart Puppet Server on config change

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,6 +71,7 @@ class satellite_pe_tools(
     setting              => 'reports',
     subsetting           => 'satellite',
     subsetting_separator => ',',
+    notify               => Service['pe-puppetserver'],
     before               => File['satellite_config_yaml'],
   }
 
@@ -81,6 +82,7 @@ class satellite_pe_tools(
     owner   => pe-puppet,
     group   => pe-puppet,
     mode    => '0644',
+    notify  => Service['pe-puppetserver'],
   }
 
   if ($manage_default_ca_cert) and ($::osfamily == 'RedHat') {


### PR DESCRIPTION
Previous to this commit, if the satellite tools configuration file
experience change, the pe-puppetserver service would not be restarted,
requiring the user to do it for the change to take effect. This is not
always clear to the user.

This commit notifies the pe-puppetserver to restart if the satellite
tools config file experiences change.
