### PR TITLE
Support AIO packaging and new CSR attributes

### DIFF
--- a/ext/kickstart/pe_kickstart_default.erb
+++ b/ext/kickstart/pe_kickstart_default.erb
@@ -83,11 +83,11 @@ echo "updating system time"
 
 
 # and add the puppet package  
-yum -t -y -e 0 install pe-agent  
+yum -t -y -e 0 install puppet-agent
 
-echo "Setting Certificate Extensions"
+echo "Setting Puppet Certificate Extensions"
 cat > /etc/puppetlabs/puppet/csr_attributes.yaml << EOF
-<%= snippet 'pe-trusted-facts.conf' %>
+<%= snippet 'puppet_csr_attributes.yaml' %>
 EOF
 
 echo "Configuring puppet"  

--- a/ext/kickstart/puppet_csr_attributes.yaml.erb
+++ b/ext/kickstart/puppet_csr_attributes.yaml.erb
@@ -4,7 +4,8 @@ name: PE Trusted Facts
 %>  
 
 <%= require 'yaml'
-   puppet_registered_extensions = ['pp_uid',
+  puppet_registered_extensions = [
+     'pp_uid',
      'pp_instance_id',
      'pp_image_name',
      'pp_preshared_key',
@@ -20,7 +21,16 @@ name: PE Trusted Facts
      'pp_software_version',
      'pp_department',
      'pp_cluster',
-     'pp_provisioner'
+     'pp_provisioner',
+     'pp_region',
+     'pp_datacenter',
+     'pp_zone',
+     'pp_network',
+     'pp_securitypolicy',
+     'pp_cloudplatform',
+     'pp_datacenter',
+     'pp_apptier',
+     'pp_hostname'
    ]
 
    csr_attributes = {'custom_attributes' => Hash.new, 'extension_requests' => Hash.new}


### PR DESCRIPTION
This commit uses the puppet-agent package name in line with the AIO
naming convention.  It also adds new CSR attributes for trusted facts.
