### PR TITLE
(maint) update metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "author": "puppetlabs",
   "summary": "Configures reports and inventory data to be sent to Satellite 6",
-  "license": "PuppetLabs-Enterprise",
+  "license": "proprietary",
   "source": "https://github.com/puppetlabs/puppetlabs-satellite_pe_tools",
   "project_page": "https://forge.puppetlabs.com/puppetlabs/satellite_pe_tools",
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
@@ -33,13 +33,8 @@
       ]
     }
   ],
-  "requirements": [
-    {
-      "name": "pe",
-      "version_requirement": ">= 3.8.0 < 2015.4.0"
-    }
-  ],
+  "requirements":[],
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0 <= 5.0.0"}
   ]
 }


### PR DESCRIPTION
The current state of the metadata.json is blocking the modulesync PR #34. This removes the PE requirement, closes the stdlib requirement, and updates the license.