### PR TITLE
(maint) Use inifile instead of pe_inifile

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,5 @@
 fixtures:
   repositories:
-    "pe_inifile": "git@github.com:puppetlabs/puppetlabs-pe_inifile.git"
+    "inifile": "git://github.com/puppetlabs/puppetlabs-inifile.git"
   symlinks:
     "satellite_pe_tools": "#{source_dir}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,7 +64,7 @@ class satellite_pe_tools(
     ssl_key  => $ssl_key,
   }
 
-  pe_ini_subsetting { 'reports_satellite' :
+  ini_subsetting { 'reports_satellite' :
     ensure               => present,
     path                 => "${::settings::confdir}/puppet.conf",
     section              => 'master',

--- a/metadata.json
+++ b/metadata.json
@@ -35,6 +35,7 @@
   ],
   "requirements":[],
   "dependencies": [
+    {"name":"puppetlabs-inifile","version_requirement":">= 1.5.0 <= 2.0.0"},
     {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0 <= 5.0.0"}
   ]
 }


### PR DESCRIPTION
pe_inifile is used internally by PE and should not be used by any
external modules, even if they are PE-only modules.