### PR TITLE
(MODULES-4511) update license_type in sync.yml

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,4 +1,7 @@
 ---
+appveyor.yml:
+  delete: true
+
 CONTRIBUTING.md:
   unmanaged: true
 
@@ -12,7 +15,7 @@ Gemfile:
     - 'katello-default-ca.crt'
 
 LICENSE:
-  unmanaged: true
+  license_type: 'puppetpe'
 
 Rakefile:
   unmanaged: true


### PR DESCRIPTION
the rest-client gem is already in .sync.yml so all that needed to be
done was updating the license_type to 'puppetpe'