### PR TITLE
(maint) add stdlib to fixtures

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,6 @@
 fixtures:
   repositories:
     "inifile": "git://github.com/puppetlabs/puppetlabs-inifile.git"
+    "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
   symlinks:
     "satellite_pe_tools": "#{source_dir}"


### PR DESCRIPTION
spec tests were failing because stdlib was not in fixtures and is a dependency for the module. this adds it (back, presmuably)