### PR TITLE
(MODULES-6893) Update README.md with parameter for Satellite 6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ parameter to the `puppet_enterprise::profile::master` class with a string value 
       capsule-certs-generate --capsule-fqdn "puppet.example.com" \
         --certs-tar "~/puppet.example.com-certs.tar"
       ```
+      Note: Use `--foreman-proxy-fqdn` instead of `--capsule-fqdn` for Satellite 6.3
 
    1. Untar the newly created file:
 


### PR DESCRIPTION
Prior to this commit, the command in step 4.i to generate capsule
certificate does not work in Satellite 6.3. The change adds a note
to include new _capsule-certs-generate_ parameter 
_--foreman-proxy-fqdn_ that works in Satellite 6.3.