### PR TITLE
(MODULES-6810) re-scan scsi bus on satellite test box

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -57,6 +57,9 @@ def ensure_subscription_manager_installed_on(host)
 end
 
 def expand_satellite_disk(host)
+  [0,1,2].each do |num|
+    on host, "echo '- - -' > /sys/class/scsi_host/host#{num}/scan"
+  end
   on host, "parted -s /dev/sdb mklabel gpt"
   on host, "parted -s /dev/sdb mkpart primary 2048 16000"
   on host, "mkfs.ext4 /dev/sdb1"


### PR DESCRIPTION
When adding a disk via the vmpooler api, the disk used to be discovered quickly enough by the satellite machine. Now, it is taking too long unless we manually rescan the (presumably virtual) scsi bus. This adds that manual command to spec_helper_acceptance