### PR TITLE
(FM-7080) - Making 2018.1 compatible

### DIFF
--- a/config/scripts/facts_terminus_config.sh
+++ b/config/scripts/facts_terminus_config.sh
@@ -18,7 +18,6 @@ read -r -d '' PE_MASTER_POST << MASTER_JSON
     "pe_repo": { },
     "pe_repo::platform::el_6_x86_64": {},
     "pe_repo::platform::el_7_x86_64": {},
-    "pe_repo::platform::ubuntu_1204_amd64": {},
     "pe_repo::platform::ubuntu_1404_amd64": {},
     "puppet_enterprise::profile::master": { "facts_terminus": "satellite" },
     "puppet_enterprise::profile::master::mcollective": {},


### PR DESCRIPTION
As ubuntu12 is no longer supported in Puppet, sending this causes a failure and classification is not updated. Removing this avoids the failure.