### PR TITLE
pdksync - (MODULES-7658) use beaker4 in puppet-module-gems

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,3 +1,5 @@
+require 'beaker-pe'
+require 'beaker-puppet'
 require 'beaker-rspec/spec_helper'
 require 'beaker-rspec/helpers/serverspec'
 require 'beaker-pe'


### PR DESCRIPTION
(MODULES-7658) use beaker4 in puppet-module-gems
pdk version: `1.7.0` 
