### PR TITLE
(FM-7529) - Updating metadata to reflect support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -29,18 +29,6 @@
       "operatingsystemrelease": [
         "7"
       ]
-    },
-    {
-      "operatingsystem": "OracleLinux",
-      "operatingsystemrelease": [
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "7"
-      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
Currently there additional OS listed in the metadata file that are not
supported. This is a bug with our documentation, therefore I am
correcting.