### PR TITLE
Fix "Could not send report to Satellite: undefined method `each_value' for Puppet::Util::Metric"

### DIFF
--- a/lib/puppet/util/satellite.rb
+++ b/lib/puppet/util/satellite.rb
@@ -113,7 +113,7 @@ module Puppet::Util::Satellite
     h = {}
     metrics.each do |_title, mtype|
       h[mtype.name] ||= {}
-      mtype.each_value { |m| h[mtype.name].merge!(m[0].to_s => m[2]) }
+      mtype.values.each { |m| h[mtype.name].merge!(m[0].to_s => m[2]) } # Puppet::Util::Metric doesn't have `each_value` # rubocop:disable Style/HashEachMethods
     end
     h
   end


### PR DESCRIPTION
This was introduced in https://github.com/puppetlabs/puppetlabs-satellite_pe_tools/commit/2d40d60dae2ede50c574bfaaa30e409d3e312d4b#diff-9b24b819c20866ac8734c5f2673c4089d5add380c90c4bd346cef094fb38473bL116-R116

Fixes #159 