### PR TITLE
pdksync - (GH-cat-8) Move CentOS 8 support to CentOS Stream 8

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -28,6 +28,7 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
+        "Stream8",
         "7"
       ]
     }


### PR DESCRIPTION
(GH-cat-8) Move CentOS 8 support to CentOS Stream 8
pdk version: `2.3.0` 
