### PR TITLE
report processor: load utils via absolute path

### DIFF
--- a/lib/puppet/indirector/facts/satellite.rb
+++ b/lib/puppet/indirector/facts/satellite.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'puppet/util/satellite'
+require __dir__ + '/../../util/satellite.rb'
 require 'puppet/indirector/facts/puppetdb'
 
 # satellite.rb

--- a/lib/puppet/reports/satellite.rb
+++ b/lib/puppet/reports/satellite.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'puppet/util/satellite'
+require __dir__ + '/../util/satellite.rb'
 
 Puppet::Reports.register_report(:satellite) do
   Puppet.settings.use(:reporting)


### PR DESCRIPTION
Fixes
https://github.com/puppetlabs/puppetlabs-satellite_pe_tools/issues/179

This fix is based on a slack conversation with Josh Cooper:
> Extensions like termini need to use require_relative to load helper
code, because when running in a server context the environment specific
directory is not added to the ruby LOAD_PATH.Or resolve the absolute
path at runtime like
https://github.com/puppetlabs/puppetlabs-splunk_hec/blob/6f2cd7beaddba20015a5d3833dacd79705b2d877/lib/puppet/indirector/facts/splunk_hec.rb#L3