### PR TITLE
(GH-185) Fix to_yaml_spec failures

### DIFF
--- a/spec/functions/to_yaml_spec.rb
+++ b/spec/functions/to_yaml_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'to_yaml' do
   let(:arg_error) do
-    [ArgumentError, 'expects']
+    [Puppet::ParseError, 'Wrong number of arguments']
   end
 
   it { is_expected.not_to eq(nil) }


### PR DESCRIPTION
Prior to this commit the to_yaml spec tests were failing. This was because the test was expecting the wrong version.

A recent release of rspec-puppet seems to have highlighted this error.

This commit fixes the failures by expecting the correct string and error type when the wrong number of parameters are passed to the to_yaml() function.