### PR TITLE
(MAINT) Bump stdlib version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.13.0 < 8.0.0"
+      "version_requirement": ">= 4.13.0 <= 8.3.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Bumping puppetlabs-stdlib max to 8.3.0 due to a dependancy conflict with puppetlabs-inifile.

https://github.com/puppetlabs/puppetlabs-inifile/blob/main/metadata.json#L13