### PR TITLE
(MAINT) - update pdk release image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 	"settings": {
 		"terminal.integrated.profiles.linux": {
 			"bash": {
-				"path": "bash",
+				"path": "bash"
 			}
 		}
 	},

--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -34,7 +34,7 @@ jobs:
         persist-credentials: false
 
     - name: "PDK Release prep"
-      uses: docker://puppet/iac_release:ci
+      uses: docker://puppet/pdk:2.6.1.0
       with:
         args: 'release prep --force'
       env:

--- a/Rakefile
+++ b/Rakefile
@@ -43,6 +43,7 @@ end
 
 PuppetLint.configuration.send('disable_relative')
 
+
 if Bundler.rubygems.find_name('github_changelog_generator').any?
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
     raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?

--- a/metadata.json
+++ b/metadata.json
@@ -38,7 +38,7 @@
       "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
-  "pdk-version": "2.5.0",
+  "pdk-version": "2.6.0 (1)",
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",
-  "template-ref": "2.7.1-0-g9a16c87"
+  "template-ref": "heads/main-0-g9375381"
 }


### PR DESCRIPTION
This PR updates the pdk release image used in auto_release.yaml from puppet/iac_release:ci to puppet/pdk:2.6.1.0.