### PR TITLE
pdksync - (MAINT) - bump puppetlabs-inifile

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-inifile",
-      "version_requirement": ">= 1.5.0 <= 6.0.0"
+      "version_requirement": ">= 1.5.0 < 7.0.0"
     },
     {
       "name": "puppetlabs-stdlib",


### PR DESCRIPTION
This PR bumps the version requirement of puppetlabs-inifile to `< 7.0.0` in preparation for the upcoming module release.
