### PR TITLE
(CONT-984) Address deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     needs: "Spec"
     runs-on: self-hosted
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Build
       run: |
         gem install bundler

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -13,7 +13,7 @@ jobs:
     needs: "Spec"
     runs-on: self-hosted
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Build
       run: |
         gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ group :development do
   gem "github_changelog_generator", '= 1.15.2',        require: false
 end
 group :system_tests do
-  gem "puppet_litmus", '<= 0.34.6', require: false, platforms: [:ruby]
+  gem "puppet_litmus", '< 2.0.0',   require: false, platforms: [:ruby]
   gem "serverspec", '~> 2.41',      require: false
 end
 


### PR DESCRIPTION
This commit updates checkout@v1 to checkout@v3 to remove some deprecation warnings in the actions