### PR TITLE
(CAT-1351) - Fixing linting issue

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,7 +75,7 @@ class satellite_pe_tools (
   if ($manage_default_ca_cert) and ($facts['os']['family'] == 'RedHat') {
     exec { 'download_install_katello_cert_rpm':
       path    => ['/usr/bin', '/bin',],
-      command => "curl -k -o /tmp/katello-ca-consumer-latest.noarch.rpm ${satellite_url}/pub/katello-ca-consumer-latest.noarch.rpm && yum -y install /tmp/katello-ca-consumer-latest.noarch.rpm", # rubocop:disable Layout/LineLength
+      command => ['curl',  '-k',  '-o', '/tmp/katello-ca-consumer-latest.noarch.rpm', "${satellite_url}/pub/katello-ca-consumer-latest.noarch.rpm", '&&', 'yum', '-y', 'install', '/tmp/katello-ca-consumer-latest.noarch.rpm'], # rubocop:disable Layout/LineLength
       creates => '/etc/rhsm/ca/katello-server-ca.pem',
     }
 


### PR DESCRIPTION
## Summary
Fixing unsafe interpolation linting issue.

## Additional Context
- Recently we have introduced unsafe string interpolation for exec command as part of https://github.com/puppetlabs/puppet-lint/pull/142.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)