### PR TITLE
pdksync - (CAT-1366) - Fix issue url from old jira to github

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
   "license": "proprietary",
   "source": "https://github.com/puppetlabs/puppetlabs-satellite_pe_tools",
   "project_page": "https://github.com/puppetlabs/puppetlabs-satellite_pe_tools",
-  "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
+  "issues_url": "https://github.com/puppetlabs/puppetlabs-satellite_pe_tools/issues",
   "dependencies": [
     {
       "name": "puppetlabs-inifile",


### PR DESCRIPTION
(CAT-1366) - Fix issue url from old jira to github
pdk version: `2.7.1` 
