### PR TITLE
pdksync - (CAT-1256) Roll out puppetlabs-puppet-lint and puppetlabs-rspec-puppet through spec_helper v7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ group :development do
   gem "parallel_tests", '= 3.12.1',              require: false
   gem "pry", '~> 0.10',                          require: false
   gem "puppet-debugger", '~> 1.0',               require: false
-  gem "puppetlabs_spec_helper", '~> 6.0',        require: false
+  gem "puppetlabs_spec_helper", '~> 7.0',        require: false
   gem "racc", '~> 1.4.0',                        require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "rspec-puppet-facts", '~> 2.0',            require: false


### PR DESCRIPTION
(CAT-1256) Roll out puppetlabs-puppet-lint and puppetlabs-rspec-puppet through spec_helper v7.0
pdk version: `2.7.1` 
