### PR TITLE
ci(MODULES-11557): add Twingate setup step to GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,16 @@ jobs:
     needs: "Spec"
     runs-on: ubuntu-24.04
     timeout-minutes: 120
+
+    env:
+      TWINGATE_PUBLIC_REPO_KEY: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
+
     steps:
+    - name: "Install Twingate"
+      uses: "twingate/github-action@v1"
+      with:
+        service-key: ${{ env.TWINGATE_PUBLIC_REPO_KEY }}
+
     - name: Checkout Source
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,16 @@ jobs:
     needs: "Spec"
     runs-on: ubuntu-24.04
     timeout-minutes: 120
+
+    env:
+      TWINGATE_PUBLIC_REPO_KEY: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
+
     steps:
+    - name: "Install Twingate"
+      uses: "twingate/github-action@v1"
+      with:
+        service-key: ${{ env.TWINGATE_PUBLIC_REPO_KEY }}
+
     - name: Checkout Source
       uses: actions/checkout@v3
       with:


### PR DESCRIPTION
## Summary
Adds the Twingate installation step in `.github/workflows/...` using `twingate/github-action@v1`. The action uses the `${{ secrets.TWINGATE_KEY }}` to establish secure access to internal resources.

This enables the workflow to access protected infrastructure during CI runs.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)